### PR TITLE
DOTNET OAS3.0 Tooling (NSwag) breekt op "," in enumeraties

### DIFF
--- a/api-specificatie/BRPB1.0.yaml
+++ b/api-specificatie/BRPB1.0.yaml
@@ -1586,8 +1586,8 @@ components:
       enum:
       - "Eigen"
       - "Partner"
-      - "Partner, eigen"
-      - "Eigen, partner"
+      - "Partner eigen"
+      - "Eigen partner"
       description: "De voorgedefinieerde waarden van naamgebruik volgens de centrale\
         \ voorzieningen. Zie attribuut Naamgebruik van groep A.1.12 Naamgebruik van\
         \ BRP."


### PR DESCRIPTION
# Impediment

DOTNET OAS3.0 Tooling (NSwag) breekt op "," in enumeraties. Deze worden gebruikt in de benamingen voor respectievelijk:

Partner, eigen
Eigen, partner

NSwag gegenereerde code:

```csharp
    public enum Naamgebruik
    {
        [System.Runtime.Serialization.EnumMember(Value = "Eigen")]
        Eigen = 0,
    
        [System.Runtime.Serialization.EnumMember(Value = "Partner")]
        Partner = 1,
    
        [System.Runtime.Serialization.EnumMember(Value = "Partner, eigen")]
        Partner,_eigen = 2,
    
        [System.Runtime.Serialization.EnumMember(Value = "Eigen, partner")]
        Eigen,_partner = 3,
    
    }
```