### PR TITLE
Readme aangepast

### DIFF
--- a/api-specificatie/README.md
+++ b/api-specificatie/README.md
@@ -1,9 +1,5 @@
 # API specificaties bevragingen ingeschreven natuurlijk personen
 Hier vind je de API specificaties in drie verschillende formaten:
-* [Open API Specificaties 3 (yaml)](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/api-specificatie/BRPB1.0.yaml)
+* Open API Specificaties 3 [(yaml)](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/api-specificatie/BRPB1.0.yaml) en [swagger](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/BRPB1.0.yaml#/ingeschrevennatuurlijkpersonen/ingeschrevennatuurlijkpersonen)
 * [JSON schema Draft 5](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/api-specificatie/BRPB1.0.json)
 * [JSON schema Draft 4 ](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/api-specificatie/BRPB1.0-2.0.json)
-
-De actuele versie wordt ook getoond op [VNG-Realisatie SwaggerHub](https://app.swaggerhub.com/apis/VNGRealisatie/Bevragingen-ingeschreven-personen/1.0), althans we proberen dit zo goed mogelijk actueel te houden. De versie hier op GitHub is de meest actuele, geldende versie.
-
-Op dit ogenblik is er een klein verschil tussen deze (gegenereerde) bestanden en de versie op Swaggerhub. Dat heeft te maken met een oplossing die we nog niet in de genereer-software hebben doorgevoerd. De versie op Swaggerhub zit op dit ogenblik dichter bij de definitieve versie dan deze bestanden. 


### PR DESCRIPTION
Verwijzing naar Swaggerhub vervangen door een link die de Github-versie van de YAML direct in een Swagger-layout toont. 