### PR TITLE
# 96 zoekvragen uit RSGB

### DIFF
--- a/docs/design_decisions.md
+++ b/docs/design_decisions.md
@@ -93,7 +93,7 @@ Uitgangspunt in de architectuur is gedelegeerde autorisatie.
 Voor ingeschreven natuurlijk personen komt er één endpoint voor het zoeken: /ingeschrevenNatuurlijkPersonen.
 Dit endpoint geeft alle attributen van de ingeschreven natuurlijk persoon van het LO GBA, geen aanhangende gegevens of gemeentelijke kerngegevens, alle relaties (die in GBA zitten) als link (uri). In de documentatie wordt in tekst aangegeven dat expand=verblijfsadres moet worden opgegeven als de consumer het verblijfsadres in het zoekresultaat wil terugkrijgen.
 
-Op dit endpoint worden alle zoekparameters die gebruikt zijn bij zoekpaden in RSGB-bevragingen 1.0 ondersteund. Alleen combinaties van parameters per zoekpad wordt ondersteund, inclusief evt. verplichting van specifieke parameters. Op andere paramters kan niet worden gezocht.
+Op dit endpoint worden alle zoekparameters uit RSGB-bevragingen 1.0 ondersteund die vallen onder "zoeken op persoonskenmerken". Alleen combinaties van parameters per zoekpad wordt ondersteund, inclusief evt. verplichting van specifieke parameters. Op andere paramters kan niet worden gezocht.
 Wanneer een client een andere combinatie gebruikt dan beschreven (bijvoorbeeld postcode + geboortedatum), moet de provider een foutmelding teruggeven.
 De ondersteunde combinaties worden in de specificaties beschreven in woorden en als uri-sjablonen.
 


### PR DESCRIPTION
Het gaat niet om alle zoekparameters uit RSGB 1.0 maar alleen die parameters die vallen onder zoeken op persoonskenmerken. Op adreskenmerken zoeken kan bij de bewoning resource.