### PR TITLE
Correctie ref in HalLink

### DIFF
--- a/api-specificatie/components.yaml
+++ b/api-specificatie/components.yaml
@@ -6,7 +6,7 @@ HalLink:
   type: object
   properties:
     href:
-      $ref: "#/components/schemas/Href"
+      $ref: "#/Href"
 HalCollectionLinks:
   type: object
   properties:


### PR DESCRIPTION
In het component HalLink staat nog een ref naar '#/components/schemas/Href' dat moet '#/Href' zijn.