### PR TITLE
Add nginx to enable secure connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,26 @@ services:
     networks:
       - brp-api-network
 
+  nginx:
+    container_name: nginx
+    image: nginx
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 1024MB
+        reservations:
+          memory: 512MB
+    ports:
+      - "443:443"
+    networks:
+      - brp-api-network
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./nginx/ssl:/etc/nginx/ssl
+    depends_on:
+      - brpproxy
+
 networks:
   brp-api-network:
     name: brp-api-network

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,20 @@
+server {
+    listen 443 ssl;
+    # Change servername according to key material
+    server_name server.example.org;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE+AESGCM;
+    ssl_prefer_server_ciphers on;
+    ssl_conf_command Options PrioritizeChaCha;
+    ssl_certificate /etc/nginx/ssl/nginx.crt;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+
+    location / {
+        proxy_pass http://brpproxy.brp-api-network:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/nginx/ssl/nginx.crt
+++ b/nginx/ssl/nginx.crt
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+Replace contents with appropriate (public) key material
+-----END CERTIFICATE-----

--- a/nginx/ssl/nginx.key
+++ b/nginx/ssl/nginx.key
@@ -1,0 +1,3 @@
+-----BEGIN PRIVATE KEY-----
+Replace contents with appropriate (private) key material
+-----END PRIVATE KEY-----


### PR DESCRIPTION
Noticing that access to BRPProxy tcp/5001 was unencrypted, I thought that it would be nice to add an option to be able use TLS too. Although probably all communication will take place within the confinements of a private network, I still think that using TLS is a good practice for the kind of information that is being transported. The only thing needed is to add the appropriate key material.