### PR TITLE
update docker-compose.yml to use local ca-certificates.txt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,8 @@ services:
       - brp-api-network
     # volumes:
     #   - ./src/config/BrpProxy/configuration:/app/configuration
-
+    # Use ca-certificates.crt provided by the Linux host running the container
+    #   - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt
   gbamock:
     container_name: gbamock
     image: ghcr.io/brp-api/haal-centraal-brp-bevragen-gba-mock:latest


### PR DESCRIPTION
When routing messages to haalcentraal.nl via an internal relay and BRPProxy is not connected to the internet directly, the dotnet application will throw an error if the certificate on that relay can not be verified as being valid. By mapping the ca-certificates.crt file that is present on the host that runs the container (which should of cource contain the correct (root) certificates) to the brpproxy container, everything should work just fine.